### PR TITLE
(#9) Improved inference interface 

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,17 +4,18 @@ from multimodal_fewshot.image import ImageInput
 magma = Magma(
     checkpoint_path = 'mp_rank_00_model_states.pt', ## downloads automatically if not present in this path
     config_path = 'configs/MAGMA_v1.yml',
+    device = 'cuda:0'
 )
-magma = magma.to('cuda:0') ## for some reason, this does not work on init
 
 inputs =[
     ImageInput('https://www.art-prints-on-demand.com/kunst/thomas_cole/woods_hi.jpg'),
-    'Describe the painting: A'
+    'Describe the painting:'
 ]
 
 ## forward pass
 embeddings = magma.preprocess_inputs(inputs = inputs)  ## returns a torch tensor of shape (1, sequence_length, hidden_dim)
-outputs = magma(embeddings) ## output logits shape: torch.Size([1, 150, 50400])
+outputs = magma(embeddings) ## output.logits shape: torch.Size([1, 150, 50400])
 
 ## high level inference
-completion = magma.generate(inputs = inputs, num_tokens = 4, topk = 1) ## completion: "cabin on a lake"
+completion = magma.generate(inputs = inputs, num_tokens = 4, filter_threshold = 0.9) ## completion: "cabin on a lake"
+print(completion)


### PR DESCRIPTION
Contains the following changes: 
1.  the `model`, `tokenizer`, and `transforms` are now contained under a unified wrapper: `Magma()` which can be used as shown below:
```python
from multimodal_fewshot import Magma

magma = Magma(
    checkpoint_path = 'mp_rank_00_model_states.pt', ## downloads automatically if not present in this path
    config_path = 'configs/MAGMA_v1.yml',
)
magma.to('cuda:0')
```

2. Image inputs are now handled by `ImageInput()`, which supports both urls and local image paths.
```python
inputs =[
	ImageInput('https://www.art-prints-on-demand.com/kunst/thomas_cole/woods_hi.jpg'),
	'Describe the painting:'
]
```

3. `Magma()` supports both low level and high level inference
```python
## forward pass
embeddings = magma.preprocess_inputs(inputs = inputs) ## returns a torch tensor of shape (1, sequence_length, hidden_dim)
outputs = magma(embeddings) ## output logits shape: torch.Size([1, 150, 50400])

## high level inference
completion = magma.generate(inputs = inputs, num_tokens = 4, topk = 1) 
## completion: "A cabin on a lake"
```