### PR TITLE
fix: requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+torch
 torchtyping
 typeguard
 git+https://github.com/finetuneanon/transformers.git#egg=transformers
@@ -7,3 +8,6 @@ timm
 git+https://github.com/openai/CLIP.git
 deepspeed
 wandb
+transformers
+einops
+clip-by-openai

--- a/requirements_for_setup.txt
+++ b/requirements_for_setup.txt
@@ -1,3 +1,4 @@
+torch
 torchtyping
 typeguard
 gdown 
@@ -5,3 +6,6 @@ tqdm
 timm
 deepspeed
 wandb
+transformers
+einops
+clip-by-openai


### PR DESCRIPTION
Have added some missing requirements when I tried to run `example_inference.py` locally.