### PR TITLE
fixing dimensionality error in argmax sampling

### DIFF
--- a/magma/sampling.py
+++ b/magma/sampling.py
@@ -94,7 +94,7 @@ def generate(
 
         # filter / temperature sample
         if temperature == 0.0:
-            next_token = torch.argmax(logits, dim=-1)
+            next_token = torch.argmax(logits, dim=-1).unsqueeze(1)
         else:
             if top_k > 0:
                 logits = top_k_filter(logits, k=top_k)


### PR DESCRIPTION
Transposing the vector to align with dimensions expected downstream.

When setting up temperature to 0, the error is:

```bash
File "magma/magma/sampling.py", line 107, in generate
    out = torch.cat((out, next_token), dim=-1)
RuntimeError: Tensors must have same number of dimensions: got 2 and 1
```

Example of the next token output:

```bash
tensor([ 257,  262,  262,  257,  257,  257, 1279,  257], device='cuda:0')
```

while the expected output is
```bash
tensor([[ 257],
        [ 262],
        [ 262],
        [ 257],
        [ 257],
        [ 257],
        [1279],
        [ 257]], device='cuda:0')
```